### PR TITLE
Support abbreviations with unicode, lowercase, spaces and periods

### DIFF
--- a/lib/redcarpet/render/html_abbreviations.rb
+++ b/lib/redcarpet/render/html_abbreviations.rb
@@ -2,7 +2,7 @@ module Redcarpet
   module Render
     module HTMLAbbreviations
 
-      REGEXP = /^\*\[([-A-Z0-9]+)\]: (.+)$/
+      REGEXP = /^\*\[([^\]]+)\]: (.+)$/
 
       def preprocess(document)
         abbreviations = document.scan(REGEXP)
@@ -25,7 +25,7 @@ module Redcarpet
       end
 
       def acronym_regexp(acronym)
-        /\b#{acronym}\b/
+        /\b#{acronym}((?<=.)|\b)/
       end
 
     end

--- a/lib/redcarpet/render/html_abbreviations.rb
+++ b/lib/redcarpet/render/html_abbreviations.rb
@@ -25,7 +25,7 @@ module Redcarpet
       end
 
       def acronym_regexp(acronym)
-        /\b#{acronym}((?<=.)|\b)/
+        /\b#{acronym}((?<=\.)|\b)/
       end
 
     end

--- a/test/redcarpet/render/html_abbreviations_test.rb
+++ b/test/redcarpet/render/html_abbreviations_test.rb
@@ -46,6 +46,17 @@ describe Redcarpet::Render::HTMLAbbreviations do
       EOS
     end
 
+    it "converts abbrevations with unicode, lowercase and spaces to HTML" do
+      markdown = <<-EOS.strip_heredoc
+        É.-U. d'A.
+
+        *[É.-U. d'A.]: États-Unis d'Amérique
+      EOS
+
+      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+        <abbr title="États-Unis d'Amérique">É.-U. d'A.</abbr>
+      EOS
+    end
   end
 
   describe "#acronym_regexp" do
@@ -74,6 +85,9 @@ describe Redcarpet::Render::HTMLAbbreviations do
       "ES6".must_match @renderer.new.acronym_regexp("ES6")
     end
 
+    it "matches " do
+      "É.-U. d'A.".must_match @renderer.new.acronym_regexp("É.-U. d'A.")
+    end
   end
 
 end

--- a/test/redcarpet/render/html_abbreviations_test.rb
+++ b/test/redcarpet/render/html_abbreviations_test.rb
@@ -85,9 +85,6 @@ describe Redcarpet::Render::HTMLAbbreviations do
       "ES6".must_match @renderer.new.acronym_regexp("ES6")
     end
 
-    it "matches " do
-      "É.-U. d'A.".must_match @renderer.new.acronym_regexp("É.-U. d'A.")
-    end
   end
 
 end

--- a/test/redcarpet/render/html_abbreviations_test.rb
+++ b/test/redcarpet/render/html_abbreviations_test.rb
@@ -57,6 +57,18 @@ describe Redcarpet::Render::HTMLAbbreviations do
         <abbr title="États-Unis d'Amérique">É.-U. d'A.</abbr>
       EOS
     end
+
+    it "doesn't convert an abbreviation which is part of a word" do
+      markdown = <<-EOS.strip_heredoc
+        This is about the event `DOMContentLoaded`.
+
+        *[DOM]: Document Object Model
+      EOS
+
+      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+        This is about the event `DOMContentLoaded`.
+      EOS
+    end
   end
 
   describe "#acronym_regexp" do

--- a/test/redcarpet/render/html_abbreviations_test.rb
+++ b/test/redcarpet/render/html_abbreviations_test.rb
@@ -1,102 +1,110 @@
-require File.expand_path("../../../test_helper", __FILE__)
+require File.expand_path('../../test_helper', __dir__)
 
 describe Redcarpet::Render::HTMLAbbreviations do
-
   before do
     @renderer = Class.new do
       include Redcarpet::Render::HTMLAbbreviations
     end
   end
 
-  describe "#preprocess" do
-
-    it "converts markdown abbrevations to HTML" do
-      markdown = <<-EOS.strip_heredoc
+  describe '#preprocess' do
+    it 'converts markdown abbrevations to HTML' do
+      markdown = <<-MARKDOWN.strip_heredoc
         YOLO
 
         *[YOLO]: You Only Live Once
-      EOS
+      MARKDOWN
 
-      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
         <abbr title="You Only Live Once">YOLO</abbr>
-      EOS
+      MARKDOWN
     end
 
-    it "converts hyphenated abbrevations to HTML" do
-      markdown = <<-EOS.strip_heredoc
+    it 'converts hyphenated abbrevations to HTML' do
+      markdown = <<-MARKDOWN.strip_heredoc
         JSON-P
 
         *[JSON-P]: JSON with Padding
-      EOS
+      MARKDOWN
 
-      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
         <abbr title="JSON with Padding">JSON-P</abbr>
-      EOS
+      MARKDOWN
     end
 
-    it "converts abbrevations with numbers to HTML" do
-      markdown = <<-EOS.strip_heredoc
+    it 'converts abbrevations with numbers to HTML' do
+      markdown = <<-MARKDOWN.strip_heredoc
         ES6
 
         *[ES6]: ECMAScript 6
-      EOS
+      MARKDOWN
 
-      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
         <abbr title="ECMAScript 6">ES6</abbr>
-      EOS
+      MARKDOWN
     end
 
-    it "converts abbrevations with unicode, lowercase and spaces to HTML" do
-      markdown = <<-EOS.strip_heredoc
+    it 'converts abbrevations with unicode, lowercase and spaces to HTML' do
+      markdown = <<-MARKDOWN.strip_heredoc
         É.-U. d'A.
 
         *[É.-U. d'A.]: États-Unis d'Amérique
-      EOS
+      MARKDOWN
 
-      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
         <abbr title="États-Unis d'Amérique">É.-U. d'A.</abbr>
-      EOS
+      MARKDOWN
     end
 
     it "doesn't convert an abbreviation which is part of a word" do
-      markdown = <<-EOS.strip_heredoc
+      markdown = <<-MARKDOWN.strip_heredoc
         This is about the event `DOMContentLoaded`.
 
         *[DOM]: Document Object Model
-      EOS
+      MARKDOWN
 
-      @renderer.new.preprocess(markdown).must_equal <<-EOS.strip_heredoc.chomp
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
         This is about the event `DOMContentLoaded`.
-      EOS
+      MARKDOWN
+    end
+
+    it "doesn't convert an abbreviation within a link URL but within the link text" do
+      markdown = <<-MARKDOWN.strip_heredoc
+        [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+
+        *[DOM]: Document Object Model
+        *[API]: Application Programming Interface
+      MARKDOWN
+
+      _(@renderer.new.preprocess(markdown)).must_equal <<-MARKDOWN.strip_heredoc.chomp
+        [<abbr title="Document Object Model">DOM</abbr>](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+      MARKDOWN
     end
   end
 
-  describe "#acronym_regexp" do
-
-    it "matches an acronym at the beginning of a line" do
-      "FOO bar".must_match @renderer.new.acronym_regexp("FOO")
+  describe '#acronym_regexp' do
+    it 'matches an acronym at the beginning of a line' do
+      _('FOO bar').must_match @renderer.new.acronym_regexp('FOO')
     end
 
-    it "matches an acronym at the end of a line" do
-      "bar FOO".must_match @renderer.new.acronym_regexp("FOO")
+    it 'matches an acronym at the end of a line' do
+      _('bar FOO').must_match @renderer.new.acronym_regexp('FOO')
     end
 
-    it "matches an acronym next to punctuation" do
-      ".FOO.".must_match @renderer.new.acronym_regexp("FOO")
+    it 'matches an acronym next to punctuation' do
+      _('.FOO.').must_match @renderer.new.acronym_regexp('FOO')
     end
 
-    it "matches an acronym with hyphens" do
-      "JSON-P".must_match @renderer.new.acronym_regexp("JSON-P")
+    it 'matches an acronym with hyphens' do
+      _('JSON-P').must_match @renderer.new.acronym_regexp('JSON-P')
     end
 
     it "doesn't match an acronym in the middle of a word" do
-      "YOLOFOOYOLO".wont_match @renderer.new.acronym_regexp("FOO")
+      _('YOLOFOOYOLO').wont_match @renderer.new.acronym_regexp('FOO')
     end
 
-    it "matches numbers" do
-      "ES6".must_match @renderer.new.acronym_regexp("ES6")
+    it 'matches numbers' do
+      _('ES6').must_match @renderer.new.acronym_regexp('ES6')
     end
-
   end
-
 end


### PR DESCRIPTION
This change makes abbreviations more generic by adding support for unicode and lowercase characters, spaces and periods.

The example I've added to the tests is taken from the PHP markdown extra spec: https://github.com/michelf/php-markdown/blob/lib/test/resources/php-markdown-extra.mdtest/Abbr.text